### PR TITLE
Reset tracking on shellcode_test

### DIFF
--- a/src/emu_shellcode.c
+++ b/src/emu_shellcode.c
@@ -444,6 +444,9 @@ traversal:
 		emu_list_insert_last(stats_tested_positions_list, eli);
 	}
 
+
+	cpu->tracking = NULL;
+
 	emu_queue_free(eq);
 	emu_env_free(env);
 


### PR DESCRIPTION
cpu->tracking wasn't set to NULL on exit, and was reused after free.