### PR TITLE
Remove harmful rpath in LDFLAGS and fix logic for cargo.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,8 +25,9 @@ case "$host" in
   pkgconfigdir="/usr/lib/pkgconfig"
   ;;
 *-*-linux*)
-  CPPFLAGS="$CPPFLAGS -D _GNU_SOURCE -I/usr/local/include -Wno-unused-local-typedefs"
-  LDFLAGS="$LDFLAGS -L/usr/local/lib -Wl,-rpath,/usr/local/lib"
+  # CPPFLAGS="$CPPFLAGS -D _GNU_SOURCE -I/usr/local/include -Wno-unused-local-typedefs"
+  CPPFLAGS="$CPPFLAGS -D _GNU_SOURCE -Wno-unused-local-typedefs"
+  # LDFLAGS="$LDFLAGS -L/usr/local/lib -Wl,-rpath,/usr/local/lib"
   pkgconfigdir="/usr/lib/pkgconfig"
   ;;
 *-*-darwin*)
@@ -175,6 +176,7 @@ AC_ARG_WITH(cargos-lib,
 
 if test x$enable_cargos = "xyes" ; then
 	OLD_CPPFLAGS=${CPPFLAGS};
+	OLD_LDFLAGS=${LDFLAGS}
 	if test x$cargos_inc != "xno"; then
 		CPPFLAGS="${CPPFLAGS} -I${cargos_inc}"
 	fi
@@ -182,7 +184,6 @@ if test x$enable_cargos = "xyes" ; then
 	AC_CHECK_HEADER(cargos-lib.h,[enable_cargos=yes],[enable_cargos=no])
 	
 	if test x$enable_cargos = "xyes" ; then
-		OLD_LDFLAGS=${LDFLAGS}
 		if test x$cargos_lib != "xno"; then
 			LDFLAGS="${LDFLAGS}  -L${cargos_lib}"
 		fi


### PR DESCRIPTION
This patch is from Debian libemu package - libemu-03_remove_rpath_and_fix_ldflags.patch
https://packages.debian.org/search?searchon=sourcenames&keywords=libemu

Description: Remove harmful rpath in LDFLAGS and fix logic for cargo.
Before this patch, libemu was searching for includes and also had an rpath
for libraries in /usr/local/lib. Also the logic for libcargo is wrong, as
makes the content of LDFLAGS empty if cargo is enabled but there are no
headers in the system. This was preventing proper hardening to be activated
in Debian.
Author: David Martínez Moreno ender@debian.org
Forwarded: no
Reviewed-By: David Martínez Moreno ender@debian.org
Last-Update: 2012-10-14