### PR TITLE
fix the automake initialization to get rid of autoreconf warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 # $Id$
 
+ACLOCAL_AMFLAGS= -I m4
+
 AUTOMAKE_OPTIONS = foreign
 
 SUBDIRS = src include testsuite doc bindings tools

--- a/configure.ac
+++ b/configure.ac
@@ -5,10 +5,11 @@
 
 AC_PREREQ(2.59)
 AC_INIT([libemu], [0.2.0], [nepenthesdev@gmail.com])
-AM_INIT_AUTOMAKE([libemu], [0.2.0])
+AM_INIT_AUTOMAKE([subdir-objects])
 AC_REVISION([$Id$])
 
 # AC_PREFIX_DEFAULT(/opt/libemu)
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_SRCDIR([include/emu/emu.h])
 AM_CONFIG_HEADER([config.h])
 # AM_MAINTAINER_MODE


### PR DESCRIPTION
More info on
https://github.com/DinoTools/libemu/issues/10